### PR TITLE
Change Type__c label. Reorder page layout.

### DIFF
--- a/src/layouts/Relationship__c-Relationship Layout.layout
+++ b/src/layouts/Relationship__c-Relationship Layout.layout
@@ -12,12 +12,8 @@
                 <field>Contact__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
-                <field>Type__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Readonly</behavior>
-                <field>Relationship_Explanation__c</field>
+                <behavior>Required</behavior>
+                <field>Status__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
@@ -26,8 +22,12 @@
                 <field>RelatedContact__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Required</behavior>
-                <field>Status__c</field>
+                <behavior>Edit</behavior>
+                <field>Type__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>Relationship_Explanation__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>

--- a/src/objects/Relationship__c.object
+++ b/src/objects/Relationship__c.object
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<<?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionOverrides>
         <actionName>Accept</actionName>
@@ -167,7 +167,7 @@ TEXT(Contact__r.Salutation) + &quot; &quot; + Contact__r.FirstName + &quot; &quo
         <description>Field that describes how the Related Contact is connected to the Contact.</description>
         <externalId>false</externalId>
         <inlineHelpText>Field that describes how the Related Contact is connected to the Contact.</inlineHelpText>
-        <label>Type</label>
+        <label>Related Type</label>
         <required>false</required>
         <trackHistory>false</trackHistory>
         <trackTrending>false</trackTrending>


### PR DESCRIPTION
# Critical Changes
* Relabels Type__c to "Related Type".
* Updates page layout for Relationship__c to better correlate related fields.

# Changes

# Issues Closed
* SalesforceFoundation/NPSP#1331
* https://ideas.salesforce.com/s/idea/a0B8W00000GdeXJUAZ